### PR TITLE
Simplify references

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,10 +1,3 @@
 export {
-  schemaRef,
-  responseRef,
-  parameterRef,
-  requestBodyRef,
-  inlineRef,
-  AllowRef,
-  Ref,
-  resolveRefs,
+  ReferableComponents,
 } from './ref';

--- a/src/utils/ref.ts
+++ b/src/utils/ref.ts
@@ -1,175 +1,57 @@
 import { Schema } from '../schema/Schema';
 import { Reference } from '../schema/Reference';
-import { Discriminator } from '../schema/Discriminator';
-import { NoExtraProperties } from './noExtraProperties';
-import { Components } from '../schema/Components';
 import {
   Parameter,
   RequestBody,
   Response,
 } from '../schema';
 
-export type AllowRef<T> =
-  T extends NoExtraProperties<Reference> ? (T | Ref<keyof Components>) :
-    T extends Discriminator ? (T | AllowRefDiscriminator) :
-      T extends Array<infer K> ? ArrayAllowRef<K> :
-        T extends object ? ObjectAllowRef<T> :
-          T;
+export class ReferableComponents {
+  private schemas: { [title: string]: Schema } = {};
 
-type AllowRefDiscriminator = {
-  mapping?: { [key: string]: string | InlineRef<Ref<'schemas'>>; };
-  propertyName: string;
-};
+  private responses: { [title: string]: Response } = {};
 
-type ComponentObjects = {
-  [K in keyof Components]-?: Exclude<NonNullable<Components[K]>[keyof Components[K]], Reference>;
-};
+  private parameters: { [title: string]: Parameter } = {};
 
-type ComponentObject<K extends keyof ComponentObjects> = ComponentObjects[K];
+  private requestBodies: { [title: string]: RequestBody } = {};
 
-type AnyComponentObject = ComponentObjects[keyof Components];
+  public schema = (title: string, schema: Schema): Reference => {
+    this.schemas[title] = schema;
 
-export type ObjectAllowRef<T extends AnyComponentObject> = {
-  [K in keyof T]: AllowRef<T[K]>;
-};
-
-export type ArrayAllowRef<K> = Array<AllowRef<K>>;
-
-export class Ref<CK extends keyof Components, V extends ObjectAllowRef<ComponentObject<CK>> = any> {
-  value: V | null;
-
-  readonly componentsKey: CK;
-
-  readonly key: string;
-
-  constructor(
-    value: null | V,
-    componentsKey: CK,
-    key: string,
-  ) {
-    this.componentsKey = componentsKey;
-    this.key = key;
-    this.value = value;
-  }
-}
-
-export function schemaRef<T extends ObjectAllowRef<Schema>>(
-  key: string,
-  schema: T | null = null,
-): Ref<'schemas', T> {
-  return new Ref(
-    schema,
-    'schemas',
-    key,
-  );
-}
-
-export function responseRef<T extends AllowRef<Response>>(
-  key: string,
-  response: T | null = null,
-): Ref<'responses', T> {
-  return new Ref(
-    response,
-    'responses',
-    key,
-  );
-}
-
-export function parameterRef<T extends AllowRef<Parameter>>(
-  key: string,
-  parameter: T | null = null,
-): Ref<'parameters', T> {
-  return new Ref(
-    parameter,
-    'parameters',
-    key,
-  );
-}
-
-export function requestBodyRef<T extends AllowRef<RequestBody>>(
-  key: string,
-  parameter: T | null = null,
-): Ref<'requestBodies', T> {
-  return new Ref(
-    parameter,
-    'requestBodies',
-    key,
-  );
-}
-
-export class InlineRef<T extends Ref<'schemas'>> {
-  readonly inlinedRef: T;
-
-  constructor(inlinedRef: T) {
-    this.inlinedRef = inlinedRef;
-  }
-}
-
-export function inlineRef<T extends Ref<'schemas'>>(
-  ref: Ref<'schemas'>,
-): InlineRef<Ref<'schemas'>> {
-  return new InlineRef(ref);
-}
-
-function toReference<K extends keyof Components>(
-  src: Ref<K>,
-  components: Components,
-  set: Set<Ref<any>>,
-): Reference {
-  const key = src.key.split(' ').join('-') as keyof Components[K];
-
-  if (!set.has(src)) {
-    set.add(src);
-    if (components[src.componentsKey] === undefined) {
-      components[src.componentsKey] = {};
-    }
-
-    components[src.componentsKey][key] = doResolveRefs(src.value, components, set) as Components[K][typeof key];
-  }
-
-  return {
-    $ref: `#/components/${src.componentsKey}/${key}`,
+    return {
+      $ref: `#/components/schemas/${title}`,
+    };
   };
-}
 
-type Resolved<T> = T extends ObjectAllowRef<infer A> ? A :
-  T extends ArrayAllowRef<infer A> ? A[] : never;
+  public response = (title: string, response: Response): Reference => {
+    this.responses[title] = response;
 
-export function resolveRefs<T>(
-  src: T,
-  components: Components,
-): Resolved<T> {
-  const set = new Set<Ref<any>>();
+    return {
+      $ref: `#/components/responses/${title}`,
+    };
+  };
 
-  return doResolveRefs(src, components, set);
-}
+  public parameter = (title: string, parameter: Parameter): Reference => {
+    this.parameters[title] = parameter;
 
-function doResolveRefs<T>(
-  src: T,
-  components: Components,
-  set: Set<Ref<any>>,
-): Resolved<T> {
-  if (Array.isArray(src)) {
-    return src.map((it) => doResolveRefs(it, components, set)) as any;
-  }
-  if (typeof src === 'object') {
-    if (src instanceof InlineRef) {
-      return toReference(src.inlinedRef, components, set).$ref as any;
-    }
-    if (src instanceof Ref) {
-      return toReference(src, components, set) as any;
-    }
+    return {
+      $ref: `#/components/parameters/${title}`,
+    };
+  };
 
-    const result: any = {};
+  public requestBody = (title: string, requestBody: RequestBody): Reference => {
+    this.requestBodies[title] = requestBody;
 
-    Object
-      .entries(src)
-      .forEach(([key, value]) => {
-        result[key] = doResolveRefs(value, components, set);
-      });
+    return {
+      $ref: `#/components/requestBodies/${title}`,
+    };
+  };
 
-    return result;
-  }
+  public getAllSchemas = () => this.schemas;
 
-  return src as any;
+  public getAllResponses = () => this.responses;
+
+  public getAllParameters = () => this.parameters;
+
+  public getAllRequestBodies = () => this.requestBodies;
 }


### PR DESCRIPTION
Current implementation of references is very hard to understand and it's difficult to determine what's wrong when TypeScript compiler fails its type checks. The solution I propose doesn't need any tool-specific utility types, interfaces and generics.

## Usage example

Create file, let's call it `ref.ts`. We should create instance of `ReferableComponents` here, it will hold all components in its state:

```typescript
// ref.ts
export const ref = new ReferableComponents();
```

To create reusable schema, that will be placed into Components section, we should write something like this:

```typescript
// Email.ts
export const EmailRef = ref.schema('Email', {
  example: 'hello@example.com',
  maxLength: 256,
  minLength: 1,
  type: 'string',
});
```

And then add everything into `components`: 

```typescript
// openapi.ts
export const openapi = (apiVersion: string): OpenAPI => ({
  components: {
    schemas: ref.getAllSchemas(),
  },
  info: info(apiVersion),
  openapi: openapiVersion,
  paths: adminPaths,
  tags: adminTags,
});
```